### PR TITLE
Documentations for version1, dev and version 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,205 +1,63 @@
+# dotmanz
 
-## ZSH Automation System — dotmanz
+A modern, Rust-powered CLI tool to manage modular ZSH configuration files.
 
-### Prerequisite: Folder Structure
+## Overview
 
-This setup assumes your ZSH environment lives under a `~/Code` directory, with the following convention:
-
-```
-
-\~/Code/
-├── dotfiles/         # This repo (your modular zsh config)
-│   └── zsh/
-├── bin/              # Your automation scripts (custom CLI tools, git-enhanced, etc.)
-
-````
-
-If you prefer a different layout (e.g. `~/configs/zsh`), **you must update paths in `aliases.zsh`, `path.zsh`, and possibly `.zshrc`** to match your structure.
-
----
-
-### What this is
-
-This folder contains a fully modular ZSH configuration setup.  
-It is intended to replace the common mess that builds up inside a `.zshrc` file over time.
-
-Instead of writing all aliases, environment variables, plugin sourcing, and prompt settings in one file, this setup **splits everything into individual files** that are easier to understand, manage, and update.
-
-You don’t need to know ZSH scripting to use this.  
-You only need to know that each file in this folder has a specific purpose, and your terminal will load it automatically.
-
----
-
-### Why this was created
-
-Before this structure, everything lived inside `.zshrc`. That included aliases, plugin sourcing, custom functions, exports, environment variables, and more. Over time, the file grew large and difficult to manage.
-
-Eventually, I made a mistake:  
-I accidentally used the `>` operator instead of `>>` while trying to add something to `.zshrc`, and it completely erased the file.
-
-That was the turning point.
-
-I decided I needed a setup that:
-
-* Would **never require me to scroll through 1000+ lines** to find a Git alias  
-* Would allow me to **safely organize and preserve** small sets of related configuration  
-* Would let **anyone else using this system understand how to extend it immediately**  
-* Would support **private secrets separately** without polluting the public config  
-* Would let me run commands like `a.aws` or `a.terraform` to explore what I had  
-
----
-
-### How this works
-
-Your `.zshrc` file is minimal and only does one thing:  
-It **sources everything** inside this folder.
-
-Every file inside this folder ends with `.zsh` and is treated as a **module**. These modules are:
-
-* Automatically loaded every time you open your terminal  
-* Small and scoped to one category (like `aws.zsh` for AWS aliases)
-
-You can edit any file independently. If you make a mistake in one, it won’t affect the others.
-
----
-
-### How to set it up
-
-1. Clone this repo:
+`dotmanz` is a command-line utility that helps developers organize, edit, and interact with modular `.zsh` files through an intuitive CLI experience. Instead of manually editing config files, you can now use commands like:
 
 ```bash
-git clone https://github.com/ayuspoudel/dotmanz ~/Code/dotfiles
-````
-
-2. Make sure your `.zshrc` file looks like this:
-
-```zsh
-ZSH_CONFIG="$HOME/Code/dotfiles/zsh"
-
-for config_file in "$ZSH_CONFIG"/*.zsh; do
-  source "$config_file"
-done
-
-[[ -f "$ZSH_CONFIG/private.zsh" ]] && source "$ZSH_CONFIG/private.zsh"
+dotmanz list
 ```
 
-3. Reload your config:
+```bash
+dotmanz add aws
+```
+
+```bash
+dotmanz edit git
+```
+
+## Features (v2.0.0+)
+
+* Rust-based binary with universal macOS support
+* Interactive CLI to create, view, edit, or delete `.zsh` modules
+* Opens your `$EDITOR` for direct file editing
+* Autoloads config from a standard modular layout
+* Works with any shell that can source `.zshrc`
+
+## Installation
+
+### 1. Download from Releases
+
+Visit [Releases](https://github.com/ayuspoudel/dotmanz/releases) and download the latest `.tar.gz` package.
+
+Or via terminal:
+
+```bash
+curl -L -o dotmanz.tar.gz https://github.com/ayuspoudel/dotmanz/releases/download/v2.0.2/dotmanz-v2.0.2.tar.gz
+tar -xzf dotmanz.tar.gz
+cd dotmanz-v2.0.2
+./install.sh
+```
+
+### 2. Reload your shell
 
 ```bash
 source ~/.zshrc
 ```
 
----
+## Documentation
 
-### The intent behind each file
-
-These files are modular and scoped. Add more if needed.
-
-#### aliases.zsh
-
-General-purpose aliases like `cls`, `czsh`, `szsh`, and quick `cd` helpers.
-If you change your folder structure, update paths in this file.
-
-#### aws.zsh
-
-Aliases for AWS CLI (EC2, IAM, Lambda, S3, etc.)
-
-#### docker.zsh
-
-Docker and Compose aliases like `dcu`, `dps`, `dcl`, etc.
-
-#### dynatrace.zsh
-
-Dynatrace environment setup (non-secret values only)
-
-#### git.zsh
-
-Git CLI shortcuts — `gpush`, `gco`, `glog`, etc.
-
-#### terraform.zsh
-
-Terraform helpers including `tfcleanapply` to reset and re-init
-
-#### helpers.zsh
-
-Magic behind `a.<group>` aliases — like:
-
-```bash
-a.aws            # List AWS aliases
-a.git push       # Search Git aliases for push-related commands
-help             # List all defined groups
-```
-
-#### path.zsh
-
-Adds `~/Code/bin` to your PATH so scripts are globally runnable
-
-#### plugins.zsh
-
-Loads ZSH plugins like autosuggestions and syntax highlighting safely
-
-#### prompt.zsh
-
-Defines your terminal appearance — username, folder, git branch, time
-
-#### private.zsh
-
-Your sensitive data: API tokens, profile exports, etc.
-**This file is ignored by Git** and should be created manually.
-
-#### safety.zsh
-
-Protects you by making `rm` interactive, formatting `less`, and improving shell history timestamps.
-
-#### automation.zsh
-
-Allows you to run scripts stored in `~/Code/bin/` using:
-
-```bash
-run                 # Lists all available scripts
-run gq              # Executes gq if it's in ~/Code/bin/
-```
-
-Use this to manage automation workflows, such as Git workflows, deployment helpers, or API tooling.
+* [Version 1.x Architecture](docs/v1.md)
+* [Developer Internals](docs/dev.md)
+* [Changelog](CHANGELOG.md)
 
 ---
 
-### How to add more
+### Coming Soon
 
-Let’s say you want aliases for Kubernetes:
-
-```bash
-touch ~/Code/dotfiles/zsh/k8s.zsh
-```
-
-```zsh
-alias kctx='kubectl config use-context'
-alias kpods='kubectl get pods'
-```
-
-Reload:
-
-```bash
-source ~/.zshrc
-```
-
-Done. You can even create `a.k8s` in `helpers.zsh` to list them like the others.
-
----
-
-### Summary
-
-This system:
-
-* Prevents you from ever losing your config again
-* Keeps everything modular and version-controlled
-* Tracks your public logic while keeping secrets private
-* Makes it easy to add/remove/configure tools in isolation
-* Gives you discovery helpers like `a.aws`, `help`, etc.
-* Can be bootstrapped in 3 minutes and extended forever
-
-You don’t need to be a shell expert. You just need to follow structure.
-And if something breaks, it only breaks one file — not your whole shell.
-
-This is a developer-first blueprint for managing your ZSH like a system.
-
+* `.deb` packaging for Linux
+* Shell completions
+* Plugin marketplace
+* Sync and refresh integrations

--- a/dev.md
+++ b/dev.md
@@ -1,0 +1,145 @@
+# dotmanz Developer Guide
+
+This document explains how the current `dotmanz` CLI (v2+) is implemented in Rust, what design principles it follows, and how to contribute or extend the system.
+
+---
+
+## Purpose
+
+The CLI replaces the need to manually manage ZSH module files. Instead of editing `~/Code/dotfiles/zsh/*.zsh` manually, users can now do:
+
+```bash
+dotmanz add aws
+dotmanz edit git
+dotmanz list
+````
+
+---
+
+## Project Structure
+
+```
+src/
+├── main.rs               # CLI entry point
+├── cli.rs                # CLI argument parser
+├── constants.rs          # Global constants (unused now)
+├── utils.rs              # Path resolver for .zshrc and zsh/ folder
+├── commands/
+│   ├── add.rs            # dotmanz add
+│   ├── edit.rs           # dotmanz edit
+│   ├── list.rs           # dotmanz list
+│   ├── remove.rs         # dotmanz remove
+│   ├── refresh.rs        # dotmanz refresh (placeholder)
+│   └── mod.rs            # Mod aggregator
+```
+
+---
+
+## Path Resolution Logic
+
+To make the tool portable and predictable, all commands operate on:
+
+```rust
+~/.dotmanz/zsh
+~/.zshrc
+```
+
+These are resolved in `utils.rs` using:
+
+```rust
+dirs::home_dir().unwrap().join(".dotmanz/zsh")
+```
+
+---
+
+## Command Flow
+
+### `dotmanz list [module]`
+
+* Lists all `.zsh` modules
+* If a module is passed, prints the file contents with highlighted alias lines
+
+### `dotmanz add [module]`
+
+* If no module is passed, opens a list prompt (`inquire::Select`)
+* Final option allows creating a new module
+* Launches `$EDITOR` to edit the module
+* On exit, triggers a `refresh.rs` placeholder for future logic
+
+### `dotmanz edit [module]`
+
+* Same as `add` but skips the "create new" option
+
+### `dotmanz remove [module]`
+
+* Warns the user about deletion
+* Opens prompt if module not supplied
+* Deletes file and confirms
+
+---
+
+## Editor Integration
+
+Uses:
+
+```rust
+let editor = std::env::var("EDITOR").unwrap_or("vi".to_string());
+Command::new(editor).arg(path).status()
+```
+
+It pauses execution until the editor is closed.
+
+---
+
+## Terminal UI (inquire)
+
+* `Select` prompt for module list
+* `Text` input for naming new modules
+
+---
+
+## Installation
+
+Binaries are prebuilt via GitHub Actions and distributed via `.tar.gz` with an `install.sh`.
+
+The installer:
+
+* Moves binary to `/usr/local/bin/dotmanz`
+* Creates `~/.dotmanz/zsh`
+* Updates `~/.zshrc` to source all modules dynamically
+
+---
+
+## GitHub Workflow
+
+* Runs on tag push (`v*`)
+* Builds a **universal macOS binary** (Intel + ARM via `lipo`)
+* Compresses all assets into `dotmanz-vX.Y.Z.tar.gz`
+* Publishes a GitHub release with metadata
+
+---
+
+## Contributing
+
+Run locally:
+
+```bash
+cargo run -- list
+cargo run -- add git
+cargo run -- edit aws
+```
+
+Build release binary:
+
+```bash
+cargo build --release
+```
+
+---
+
+## Roadmap
+
+* Shell completion support
+* Plugin discovery
+* Sync integration (`dotmanz refresh`)
+* Auto-lint and validate aliases

--- a/v1.md
+++ b/v1.md
@@ -1,0 +1,138 @@
+
+# Version 1 — Architecture
+
+This document explains the original `dotmanz` ZSH configuration system (v1.0.0), which focused on creating a clean, structured, and modular environment for `.zshrc` configurations using plain shell scripting and directory structure.
+
+## Philosophy
+
+The purpose of v1 was to avoid monolithic `.zshrc` files and allow developers to:
+
+- Organize aliases, functions, and exports into isolated files
+- Safely manage updates without breaking entire configs
+- Preserve secrets and plugins separately
+- Make shell onboarding for new team members extremely simple
+
+---
+
+## Folder Structure
+
+```bash
+~/Code/
+├── dotfiles/         # Your main config repo
+│   └── zsh/          # Modular ZSH configuration files
+├── bin/              # Optional: your automation scripts
+````
+
+---
+
+## `.zshrc` Template
+
+The `.zshrc` file in this setup is minimal:
+
+```zsh
+ZSH_CONFIG="$HOME/Code/dotfiles/zsh"
+
+for config_file in "$ZSH_CONFIG"/*.zsh; do
+  source "$config_file"
+done
+
+[[ -f "$ZSH_CONFIG/private.zsh" ]] && source "$ZSH_CONFIG/private.zsh"
+```
+
+This loop automatically loads all `.zsh` modules in the folder and includes secrets if present.
+
+---
+
+## What Each File Did
+
+### `aliases.zsh`
+
+* Common shell shortcuts like `cls`, `czsh`, `szsh`, and project directory jumps
+
+### `aws.zsh`
+
+* AWS CLI profiles and helpful aliases for S3, EC2, IAM, etc.
+
+### `docker.zsh`
+
+* Shortcuts like `dcu`, `dcl`, `dps` for Docker/Compose workflows
+
+### `dynatrace.zsh`
+
+* Dynatrace-related environment variables (non-secret)
+
+### `git.zsh`
+
+* Git power aliases like `gpush`, `gco`, `glog`, `gundo`, etc.
+
+### `terraform.zsh`
+
+* `tfcleanapply`, `tfplanout`, etc. to improve Terraform dev experience
+
+### `helpers.zsh`
+
+* Defines functions like `a.aws`, `a.git`, etc. for discovering group aliases
+
+### `path.zsh`
+
+* Adds `~/Code/bin` or other utility folders to `$PATH`
+
+### `plugins.zsh`
+
+* Safely sources ZSH plugins (autosuggestions, completions)
+
+### `prompt.zsh`
+
+* Customizes prompt with folder, time, branch, etc.
+
+### `private.zsh`
+
+* Stores secrets (ignored by Git)
+
+### `safety.zsh`
+
+* Safer `rm`, improved `less`, better timestamp handling
+
+### `automation.zsh`
+
+* Adds `run <script>` support for executing things inside `~/Code/bin`
+
+---
+
+## Adding a New Module
+
+```bash
+touch ~/Code/dotfiles/zsh/k8s.zsh
+```
+
+Add aliases:
+
+```zsh
+alias kctx='kubectl config use-context'
+alias kpods='kubectl get pods'
+```
+
+Reload:
+
+```bash
+source ~/.zshrc
+```
+
+---
+
+## Why This Mattered
+
+This setup avoided fragile `.zshrc` clutter and made it easy to:
+
+* Version control configs
+* Move across machines
+* Work in a team-friendly way
+* Instantly bootstrap any shell environment
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This issue tracks the creation and addition of versioned and developer-focused documentation files into the `dotmanz` repository.
As the project has evolved from a Bash-based config system (v1) to a Rust-based CLI tool (v2), we need clear documentation for:
* Legacy users familiar with the original modular `.zshrc` system
* Developers who want to understand and contribute to the Rust CLI tool
* End users who want to know how to install and use the tool
* [x] Create `docs/v1.md` to document the original Bash-based modular system
* [x] Create `docs/dev.md` to document the internal structure and Rust architecture
* [x] Update main `README.md` to:
  * Focus on v2 CLI functionality
  * Link to `docs/v1.md` and `docs/dev.md`
  * Provide an installation guide using prebuilt binaries
* [x] Ensure all docs are written in clean, developer-friendly Markdown
Improved clarity for users and contributors:
* Users understand what changed from v1 to v2
* Developers can contribute without reverse engineering the CLI
* The tool becomes easier to adopt and extend

Closes #
