### PR TITLE
Updated install.sh (streamable via curl)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,34 +9,34 @@ RED="\033[0;31m"
 RESET="\033[0m"
 
 # Paths
-REPO_DIR="$(cd "$(dirname "$0")" && pwd)"
 INSTALL_DIR="$HOME/.dotmanz"
 INSTALL_BIN="$INSTALL_DIR/dotmanz"
 SYSTEM_BIN="/usr/local/bin/dotmanz"
 ZSHRC="$HOME/.zshrc"
 
+# GitHub release info
+REPO="ayuspoudel/dotmanz"
+TAR_URL="https://github.com/$REPO/releases/latest/download/dotmanz-v2.0.3.tar.gz"
+
 # Step 1: Prepare target
 mkdir -p "$INSTALL_DIR"
 
-# Step 2: Copy binary
-if [[ ! -f "$REPO_DIR/dotmanz" ]]; then
-  echo -e "${RED}Error:${RESET} dotmanz binary not found in $REPO_DIR"
-  exit 1
-fi
+# Step 2: Download and extract binary
+echo -e "${YELLOW}Downloading dotmanz binary...${RESET}"
+curl -sL "$TAR_URL" | tar -xz -C "$INSTALL_DIR"
 
-echo -e "${YELLOW}Installing dotmanz binary...${RESET}"
-cp "$REPO_DIR/dotmanz" "$INSTALL_BIN"
+# Step 3: Make binary executable
 chmod +x "$INSTALL_BIN"
 
-# Step 3: Copy ZSH modules
+# Step 4: Copy ZSH modules
 echo -e "${YELLOW}Copying ZSH modules...${RESET}"
-cp -r "$REPO_DIR/zsh" "$INSTALL_DIR/zsh"
+curl -sL "https://github.com/$REPO/archive/refs/heads/version-1.tar.gz" | tar -xz --strip-components=2 -C "$INSTALL_DIR" "dotmanz-version-1/zsh"
 
-# Step 4: Link to /usr/local/bin
+# Step 5: Link to /usr/local/bin
 echo -e "${YELLOW}Linking CLI to /usr/local/bin...${RESET}"
 sudo ln -sf "$INSTALL_BIN" "$SYSTEM_BIN"
 
-# Step 5: Patch .zshrc to source from ~/.dotmanz/zsh
+# Step 6: Patch .zshrc
 HEADER_LINE="# dotmanz module loader"
 SOURCE_LINE='for f in $HOME/.dotmanz/zsh/*.zsh; do source "$f"; done'
 


### PR DESCRIPTION
Fix: Download the Release Binary Instead
Let’s update the script to:
Download the .tar.gz file from GitHub Releases
Extract it into ~/.dotmanz/
Continue installing as before

Closes #43