### PR TITLE
Update to fix no refresh feature

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,9 +26,10 @@ pub enum Commands {
 
     /// Add a module to .zshrc
     Add {
-        /// Optional: name of the module to edit directly
+        #[arg(long)]
+        no_refresh: bool,
         module: Option<String>,
-    },
+    }
 
     /// Remove a module from .zshrc
     Remove { module: Option<String> },

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,10 @@ fn main() {
         Commands::List { verbose, module, filter } => {
             commands::list::run(*verbose, module.as_deref(), filter.as_deref());
         }
-        Commands::Add { module } => {
+        Commands::Add { module, no_refresh } => {
             commands::add::run(module.as_deref(), !no_refresh);
         }
+
         Commands::Remove { module } => {
             match module.as_deref() {
                 Some(name) => commands::remove::run(name),


### PR DESCRIPTION
error in trying to use no_refresh, since it doesn't exist in that scope — likely because it is accessing the Add variant of the Commands enum incorrectly.

Closes #62