### PR TITLE
Final Polish (Cosmetic Only)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,7 +29,7 @@ pub enum Commands {
         #[arg(long)]
         no_refresh: bool,
         module: Option<String>,
-    }
+    },
 
     /// Remove a module from .zshrc
     Remove { module: Option<String> },
@@ -42,5 +42,5 @@ pub enum Commands {
         #[arg(value_enum)]
         shell: clap_complete::Shell,
     },
-    Version
+    Version,
 }


### PR DESCRIPTION
Style: Add a comma after the last enum variant
Rust allows trailing commas in enum definitions. It prevents git diffs when you add new variants later.

Closes #64